### PR TITLE
0.5 update

### DIFF
--- a/data/CSL.py
+++ b/data/CSL.py
@@ -138,8 +138,7 @@ class CSL(torch.utils.data.Dataset):
         t0 = time.time()
         print("[I] Preparing Circular Skip Link Graphs v4 ...")
         for sample in self.adj_list:
-            _g = dgl.DGLGraph()
-            _g.from_scipy_sparse_matrix(sample)
+            _g = dgl.from_scipy(sample)
             g = dgl.transform.remove_self_loop(_g)
             g.ndata['feat'] = torch.zeros(g.number_of_nodes()).long()
             #g.ndata['feat'] = torch.arange(0, g.number_of_nodes()).long() # v1

--- a/data/script_download_all_datasets_dgl0.5.sh
+++ b/data/script_download_all_datasets_dgl0.5.sh
@@ -1,0 +1,124 @@
+
+
+# Command to download dataset:
+#   bash script_download_all_datasets.sh
+
+
+
+############
+# ZINC
+############
+
+DIR=molecules/
+cd $DIR
+
+FILE=ZINC.pkl
+if test -f "$FILE"; then
+	echo -e "$FILE already downloaded."
+else
+	echo -e "\ndownloading $FILE..."
+	curl https://data.dgl.ai/dataset/benchmarking-gnns/ZINC.pkl -o ZINC.pkl -J -L -k
+fi
+
+cd ..
+
+
+############
+# MNIST and CIFAR10
+############
+
+DIR=superpixels/
+cd $DIR
+
+FILE=MNIST.pkl
+if test -f "$FILE"; then
+	echo -e "$FILE already downloaded."
+else
+	echo -e "\ndownloading $FILE..."
+	curl https://data.dgl.ai/dataset/benchmarking-gnns/MNIST.pkl -o MNIST.pkl -J -L -k
+fi
+
+FILE=CIFAR10.pkl
+if test -f "$FILE"; then
+	echo -e "$FILE already downloaded."
+else
+	echo -e "\ndownloading $FILE..."
+	curl https://data.dgl.ai/dataset/benchmarking-gnns/CIFAR10.pkl -o CIFAR10.pkl -J -L -k
+fi
+
+cd ..
+
+
+############
+# PATTERN and CLUSTER 
+############
+
+DIR=SBMs/
+cd $DIR
+
+FILE=SBM_CLUSTER.pkl
+if test -f "$FILE"; then
+	echo -e "$FILE already downloaded."
+else
+	echo -e "\ndownloading $FILE..."
+	curl https://data.dgl.ai/dataset/benchmarking-gnns/SBM_CLUSTER.pkl -o SBM_CLUSTER.pkl -J -L -k
+fi
+
+FILE=SBM_PATTERN.pkl
+if test -f "$FILE"; then
+	echo -e "$FILE already downloaded."
+else
+	echo -e "\ndownloading $FILE..."
+	curl https://data.dgl.ai/dataset/benchmarking-gnns/SBM_PATTERN.pkl -o SBM_PATTERN.pkl -J -L -k
+fi
+
+cd ..
+
+
+############
+# TSP 
+############
+
+DIR=TSP/
+cd $DIR
+
+FILE=TSP.pkl
+if test -f "$FILE"; then
+	echo -e "$FILE already downloaded."
+else
+	echo -e "\ndownloading $FILE..."
+	curl https://data.dgl.ai/dataset/benchmarking-gnns/TSP.pkl -o TSP.pkl -J -L -k
+fi
+
+cd ..
+
+
+############
+# CSL 
+############
+
+DIR=CSL/
+cd $DIR
+
+FILE=CSL.zip
+if test -f "$FILE"; then
+	echo -e "$FILE already downloaded."
+else
+	echo -e "\ndownloading $FILE..."
+	curl https://www.dropbox.com/s/rnbkp5ubgk82ocu/CSL.zip?dl=1 -o CSL.zip -J -L -k
+	unzip CSL.zip -d ./
+	rm -r __MACOSX/
+fi
+
+cd ..
+
+
+
+
+
+
+
+
+
+
+

--- a/docs/02_download_datasets.md
+++ b/docs/02_download_datasets.md
@@ -1,5 +1,6 @@
 # Download datasets
 
+The following sections except the last one only work for versions before DGL 0.5.  If you have DGL 0.5 or later, please refer to the last section.
 
 <br>
 
@@ -94,9 +95,16 @@ bash script_download_all_datasets.sh
 
 Script [script_download_all_datasets.sh](../data/script_download_all_datasets.sh) is located here. 
 
+## 9. All datasets with DGL 0.5 or later
 
+```
+# At the root of the project
+cd data/
+bash script_download_all_datasets_dgl0.5.sh
+```
 
+Script [script_download_all_datasets_dgl0.5.sh](../data/script_download_all_datasets_dgl0.5.sh) is located here. 
 
-
+If you previously had DGL 0.4.3post2 or earlier versions, you will need to remove the downloaded pickle files and run the script above to redownload the datasets to migrate to DGL 0.5.
 
 <br><br><br>

--- a/layers/gat_layer.py
+++ b/layers/gat_layer.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+import dgl
 from dgl.nn.pytorch import GATConv
 
 """
@@ -41,7 +42,10 @@ class GATLayer(nn.Module):
         if in_dim != (out_dim*num_heads):
             self.residual = False
 
-        self.gatconv = GATConv(in_dim, out_dim, num_heads, dropout, dropout)
+        if dgl.__version__ < "0.5":
+            self.gatconv = GATConv(in_dim, out_dim, num_heads, dropout, dropout)
+        else:
+            self.gatconv = GATConv(in_dim, out_dim, num_heads, dropout, dropout, allow_zero_in_degree=True)
 
         if self.batch_norm:
             self.batchnorm_h = nn.BatchNorm1d(out_dim * num_heads)

--- a/layers/gcn_layer.py
+++ b/layers/gcn_layer.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+import dgl
 import dgl.function as fn
 from dgl.nn.pytorch import GraphConv
 
@@ -49,8 +50,10 @@ class GCNLayer(nn.Module):
         self.dropout = nn.Dropout(dropout)
         if self.dgl_builtin == False:
             self.apply_mod = NodeApplyModule(in_dim, out_dim)
-        else:
+        elif dgl.__version__ < "0.5":
             self.conv = GraphConv(in_dim, out_dim)
+        else:
+            self.conv = GraphConv(in_dim, out_dim, allow_zero_in_degree=True)
 
         
     def forward(self, g, feature):

--- a/nets/CSL_graph_classification/mo_net.py
+++ b/nets/CSL_graph_classification/mo_net.py
@@ -89,8 +89,8 @@ class MoNet(nn.Module):
     def compute_pseudo(self, edges):
         # compute pseudo edge features for MoNet
         # to avoid zero division in case in_degree is 0, we add constant '1' in all node degrees denoting self-loop
-        srcs = 1/np.sqrt(edges.src['deg']+1)
-        dsts = 1/np.sqrt(edges.dst['deg']+1)
+        srcs = 1/torch.sqrt(edges.src['deg'].float()+1)
+        dsts = 1/torch.sqrt(edges.dst['deg'].float()+1)
         pseudo = torch.cat((srcs.unsqueeze(-1), dsts.unsqueeze(-1)), dim=1)
         return {'pseudo': pseudo}
 

--- a/nets/SBMs_node_classification/mo_net.py
+++ b/nets/SBMs_node_classification/mo_net.py
@@ -69,8 +69,8 @@ class MoNet(nn.Module):
     def compute_pseudo(self, edges):
         # compute pseudo edge features for MoNet
         # to avoid zero division in case in_degree is 0, we add constant '1' in all node degrees denoting self-loop
-        srcs = 1/np.sqrt(edges.src['deg']+1)
-        dsts = 1/np.sqrt(edges.dst['deg']+1)
+        srcs = 1/torch.sqrt(edges.src['deg'].float()+1)
+        dsts = 1/torch.sqrt(edges.dst['deg'].float()+1)
         pseudo = torch.cat((srcs.unsqueeze(-1), dsts.unsqueeze(-1)), dim=1)
         return {'pseudo': pseudo}
         

--- a/nets/TSP_edge_classification/mo_net.py
+++ b/nets/TSP_edge_classification/mo_net.py
@@ -76,8 +76,8 @@ class MoNet(nn.Module):
     def compute_pseudo(self, edges):
         # compute pseudo edge features for MoNet
         # to avoid zero division in case in_degree is 0, we add constant '1' in all node degrees denoting self-loop
-        srcs = 1/np.sqrt(edges.src['deg']+1)
-        dsts = 1/np.sqrt(edges.dst['deg']+1)
+        srcs = 1/torch.sqrt(edges.src['deg'].float()+1)
+        dsts = 1/torch.sqrt(edges.dst['deg'].float()+1)
         pseudo = torch.cat((srcs.unsqueeze(-1), dsts.unsqueeze(-1)), dim=1)
         return {'pseudo': pseudo}
     

--- a/nets/TUs_graph_classification/mo_net.py
+++ b/nets/TUs_graph_classification/mo_net.py
@@ -78,8 +78,8 @@ class MoNet(nn.Module):
     def compute_pseudo(self, edges):
         # compute pseudo edge features for MoNet
         # to avoid zero division in case in_degree is 0, we add constant '1' in all node degrees denoting self-loop
-        srcs = 1/np.sqrt(edges.src['deg']+1)
-        dsts = 1/np.sqrt(edges.dst['deg']+1)
+        srcs = 1/torch.sqrt(edges.src['deg'].float()+1)
+        dsts = 1/torch.sqrt(edges.dst['deg'].float()+1)
         pseudo = torch.cat((srcs.unsqueeze(-1), dsts.unsqueeze(-1)), dim=1)
         return {'pseudo': pseudo}
         

--- a/nets/molecules_graph_regression/mo_net.py
+++ b/nets/molecules_graph_regression/mo_net.py
@@ -77,8 +77,8 @@ class MoNet(nn.Module):
     def compute_pseudo(self, edges):
         # compute pseudo edge features for MoNet
         # to avoid zero division in case in_degree is 0, we add constant '1' in all node degrees denoting self-loop
-        srcs = 1/np.sqrt(edges.src['deg']+1)
-        dsts = 1/np.sqrt(edges.dst['deg']+1)
+        srcs = 1/torch.sqrt(edges.src['deg'].float()+1)
+        dsts = 1/torch.sqrt(edges.dst['deg'].float()+1)
         pseudo = torch.cat((srcs.unsqueeze(-1), dsts.unsqueeze(-1)), dim=1)
         return {'pseudo': pseudo}
 

--- a/nets/superpixels_graph_classification/mo_net.py
+++ b/nets/superpixels_graph_classification/mo_net.py
@@ -78,8 +78,8 @@ class MoNet(nn.Module):
     def compute_pseudo(self, edges):
         # compute pseudo edge features for MoNet
         # to avoid zero division in case in_degree is 0, we add constant '1' in all node degrees denoting self-loop
-        srcs = 1/np.sqrt(edges.src['deg']+1)
-        dsts = 1/np.sqrt(edges.dst['deg']+1)
+        srcs = 1/torch.sqrt(edges.src['deg'].float()+1)
+        dsts = 1/torch.sqrt(edges.dst['deg'].float()+1)
         pseudo = torch.cat((srcs.unsqueeze(-1), dsts.unsqueeze(-1)), dim=1)
         return {'pseudo': pseudo}    
     

--- a/train/train_CSL_graph_classification.py
+++ b/train/train_CSL_graph_classification.py
@@ -20,6 +20,7 @@ def train_epoch_sparse(model, optimizer, device, data_loader, epoch):
     for iter, (batch_graphs, batch_labels) in enumerate(data_loader):
         batch_x = batch_graphs.ndata['feat'].to(device)  # num x feat
         batch_e = batch_graphs.edata['feat'].to(device)
+        batch_graphs = batch_graphs.to(device)
         batch_labels = batch_labels.to(device)
         optimizer.zero_grad()
         try:
@@ -50,6 +51,7 @@ def evaluate_network_sparse(model, device, data_loader, epoch):
         for iter, (batch_graphs, batch_labels) in enumerate(data_loader):
             batch_x = batch_graphs.ndata['feat'].to(device)
             batch_e = batch_graphs.edata['feat'].to(device)
+            batch_graphs = batch_graphs.to(device)
             batch_labels = batch_labels.to(device)
             try:
                 batch_pos_enc = batch_graphs.ndata['pos_enc'].to(device)

--- a/train/train_SBMs_node_classification.py
+++ b/train/train_SBMs_node_classification.py
@@ -20,6 +20,7 @@ def train_epoch_sparse(model, optimizer, device, data_loader, epoch):
     nb_data = 0
     gpu_mem = 0
     for iter, (batch_graphs, batch_labels) in enumerate(data_loader):
+        batch_graphs = batch_graphs.to(device)
         batch_x = batch_graphs.ndata['feat'].to(device)  # num x feat
         batch_e = batch_graphs.edata['feat'].to(device)
         batch_labels = batch_labels.to(device)
@@ -51,6 +52,7 @@ def evaluate_network_sparse(model, device, data_loader, epoch):
     nb_data = 0
     with torch.no_grad():
         for iter, (batch_graphs, batch_labels) in enumerate(data_loader):
+            batch_graphs = batch_graphs.to(device)
             batch_x = batch_graphs.ndata['feat'].to(device)
             batch_e = batch_graphs.edata['feat'].to(device)
             batch_labels = batch_labels.to(device)

--- a/train/train_TSP_edge_classification.py
+++ b/train/train_TSP_edge_classification.py
@@ -20,6 +20,7 @@ def train_epoch_sparse(model, optimizer, device, data_loader, epoch):
     nb_data = 0
     gpu_mem = 0
     for iter, (batch_graphs, batch_labels) in enumerate(data_loader):
+        batch_graphs = batch_graphs.to(device)
         batch_x = batch_graphs.ndata['feat'].to(device)  # num x feat
         batch_e = batch_graphs.edata['feat'].to(device)
         batch_labels = batch_labels.to(device)
@@ -45,6 +46,7 @@ def evaluate_network_sparse(model, device, data_loader, epoch):
     nb_data = 0
     with torch.no_grad():
         for iter, (batch_graphs, batch_labels) in enumerate(data_loader):
+            batch_graphs = batch_graphs.to(device)
             batch_x = batch_graphs.ndata['feat'].to(device)
             batch_e = batch_graphs.edata['feat'].to(device)
             batch_labels = batch_labels.to(device)

--- a/train/train_TUs_graph_classification.py
+++ b/train/train_TUs_graph_classification.py
@@ -20,6 +20,7 @@ def train_epoch_sparse(model, optimizer, device, data_loader, epoch):
     for iter, (batch_graphs, batch_labels) in enumerate(data_loader):
         batch_x = batch_graphs.ndata['feat'].to(device)  # num x feat
         batch_e = batch_graphs.edata['feat'].to(device)
+        batch_graphs = batch_graphs.to(device)
         batch_labels = batch_labels.to(device)
         optimizer.zero_grad()
         
@@ -45,6 +46,7 @@ def evaluate_network_sparse(model, device, data_loader, epoch):
             batch_x = batch_graphs.ndata['feat'].to(device)
             batch_e = batch_graphs.edata['feat'].to(device)
             batch_labels = batch_labels.to(device)
+            batch_graphs = batch_graphs.to(device)
             
             batch_scores = model.forward(batch_graphs, batch_x, batch_e)
             loss = model.loss(batch_scores, batch_labels) 

--- a/train/train_molecules_graph_regression.py
+++ b/train/train_molecules_graph_regression.py
@@ -18,6 +18,7 @@ def train_epoch_sparse(model, optimizer, device, data_loader, epoch):
     nb_data = 0
     gpu_mem = 0
     for iter, (batch_graphs, batch_targets) in enumerate(data_loader):
+        batch_graphs = batch_graphs.to(device)
         batch_x = batch_graphs.ndata['feat'].to(device)  # num x feat
         batch_e = batch_graphs.edata['feat'].to(device)
         batch_targets = batch_targets.to(device)
@@ -48,6 +49,7 @@ def evaluate_network_sparse(model, device, data_loader, epoch):
     nb_data = 0
     with torch.no_grad():
         for iter, (batch_graphs, batch_targets) in enumerate(data_loader):
+            batch_graphs = batch_graphs.to(device)
             batch_x = batch_graphs.ndata['feat'].to(device)
             batch_e = batch_graphs.edata['feat'].to(device)
             batch_targets = batch_targets.to(device)

--- a/train/train_superpixels_graph_classification.py
+++ b/train/train_superpixels_graph_classification.py
@@ -18,6 +18,7 @@ def train_epoch_sparse(model, optimizer, device, data_loader, epoch):
     nb_data = 0
     gpu_mem = 0
     for iter, (batch_graphs, batch_labels) in enumerate(data_loader):
+        batch_graphs = batch_graphs.to(device)
         batch_x = batch_graphs.ndata['feat'].to(device)  # num x feat
         batch_e = batch_graphs.edata['feat'].to(device)
         batch_labels = batch_labels.to(device)
@@ -42,6 +43,7 @@ def evaluate_network_sparse(model, device, data_loader, epoch):
     nb_data = 0
     with torch.no_grad():
         for iter, (batch_graphs, batch_labels) in enumerate(data_loader):
+            batch_graphs = batch_graphs.to(device)
             batch_x = batch_graphs.ndata['feat'].to(device)
             batch_e = batch_graphs.edata['feat'].to(device)
             batch_labels = batch_labels.to(device)


### PR DESCRIPTION
DGL 0.5 changed the data structure of `DGLGraph`.  This PR is to update the codebase and datasets, as well as the instructions to download the new datasets, for DGL 0.5.

The updated datasets have identical graphs and features to the original one.

[EDIT] Currently the new datasets are hosted on https://data.dgl.ai.  If you would like to host it in a different place please let me know.

Also made some changes to the code to make the models work for DGL 0.5 as well.

The code will still work for DGL 0.4.3post2 or earlier versions.