### PR TITLE
Update ZINC-full link to DGL hosted

### DIFF
--- a/data/script_download_all_datasets.sh
+++ b/data/script_download_all_datasets.sh
@@ -25,7 +25,7 @@ if test -f "$FILE"; then
 	echo -e "$FILE already downloaded."
 else
 	echo -e "\ndownloading $FILE..."
-	curl https://www.dropbox.com/s/gpzovwqqsudarvq/ZINC-full.pkl?dl=1 -o ZINC-full.pkl -J -L -k
+	curl https://data.dgl.ai/dataset/benchmarking-gnns/ZINC-full.pkl -o ZINC-full.pkl -J -L -k
 fi
 
 cd ..

--- a/data/script_download_molecules.sh
+++ b/data/script_download_molecules.sh
@@ -22,7 +22,7 @@ if test -f "$FILE"; then
 	echo -e "$FILE already downloaded."
 else
 	echo -e "\ndownloading $FILE..."
-	curl https://www.dropbox.com/s/gpzovwqqsudarvq/ZINC-full.pkl?dl=1 -o ZINC-full.pkl -J -L -k
+	curl https://data.dgl.ai/dataset/benchmarking-gnns/ZINC-full.pkl -o ZINC-full.pkl -J -L -k
 fi
 
 


### PR DESCRIPTION
I uploaded the new ZINC-full dataset to data.dgl.ai to match the other datasets.